### PR TITLE
DTM-1916

### DIFF
--- a/pkg/usecases/authentication/authcode.go
+++ b/pkg/usecases/authentication/authcode.go
@@ -45,7 +45,6 @@ func (u *AuthCode) Do(ctx context.Context, o *AuthCodeOption, client oidcclient.
 			if !ok {
 				return nil
 			}
-			u.Logger.Printf("Open %s for authentication", url)
 			if u.LocalServerReadyFunc != nil {
 				u.LocalServerReadyFunc(url)
 			}


### PR DESCRIPTION
The “Open http://localhost:18000 for authentication” message is confusing for people. They tend to click on the URL and don’t understand what is going on. Remove/hide the message.