### PR TITLE
Tribe Transfer: DevOPS Tooling → Developer Productivity

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pipedrive/developer-productivity

--- a/repository.json
+++ b/repository.json
@@ -1,7 +1,7 @@
 {
   "name": "kubelogin",
   "description": "Forked int128 which support okta implicit authorization flow kubelogin utility",
-  "owner": "DevOPS Tooling",
+  "owner": "Developer Productivity",
   "type": "library",
   "status": "released"
 }


### PR DESCRIPTION
## Summary
- Update `repository.json` owner from `DevOPS Tooling` to `Developer Productivity`
- Update `CODEOWNERS` to reflect new team ownership

Part of the DevOps Tooling tribe split.